### PR TITLE
383-2 Warn instructors when evaluation notes aren't saved

### DIFF
--- a/client/src/inside/components/EhrContextInstructor.vue
+++ b/client/src/inside/components/EhrContextInstructor.vue
@@ -15,14 +15,21 @@
       div(class="is-4 column")
         div(class="columns is-pulled-right")
           div {{currentIndex}} of {{listLen}}
-          ui-button(v-on:buttonClicked="previousStudent", class="is-pulled-right is-light", :disabled="!enablePrev")
+          ui-button(v-on:buttonClicked="handleConfirmNavigation('previous')", class="is-pulled-right is-light", :disabled="!enablePrev")
             fas-icon(icon="angle-left", class="icon-left")
             span Previous
-          ui-button(v-on:buttonClicked="nextStudent", class="is-pulled-right is-light", :disabled="!enableNext")
+          ui-button(v-on:buttonClicked="handleConfirmNavigation('next')", class="is-pulled-right is-light", :disabled="!enableNext")
             span Next &nbsp;
             fas-icon(icon="angle-right", class="icon-left")
     div(class="textField") Evaluation notes
-    ehr-evaluation-input(ref="evaluationNoteComponent", v-on:saveNext="nextStudent", :enableNext="enableNext")
+    ehr-evaluation-input(
+      ref="evaluationNoteComponent", 
+      v-on:saveNext="nextStudent", 
+      :enableNext="enableNext", 
+      :shouldConfirmNavigation="shouldConfirmNavigation"
+      :navigation="navigation"
+      @proceedNavigation="handleProceedNavigation"
+    )
 </template>
 
 <script>
@@ -36,6 +43,12 @@ import StoreHelper from '../../helpers/store-helper'
 export default {
   name: 'EhrClassListNav',
   components: { UiLink, UiButton, EhrEvaluationInput, UiInfo },
+  data: function () {
+    return {
+      shouldConfirmNavigation: false,
+      navigation: ''
+    }
+  },
   computed: {
     panelInfo () {
       return StoreHelper.getPanelData()
@@ -97,7 +110,20 @@ export default {
         this.changeStudent(sv)
       }
     },
-    changeStudent (sv) { StoreHelper.changeStudentForInstructor( sv._id ) }
+    changeStudent (sv) { StoreHelper.changeStudentForInstructor( sv._id ) },
+    handleConfirmNavigation (type) {
+      this.navigation = type
+      this.shouldConfirmNavigation = true
+    },
+    handleProceedNavigation () {
+      if(this.navigation === 'previous') {
+        this.previousStudent()
+      } else if (this.navigation === 'next'){
+        this.nextStudent()
+      }
+      this.shouldConfirmNavigation = false
+      this.navigation = ''
+    }
   },
   mounted: function () {
     StoreHelper.loadInstructorWithStudent(true)

--- a/client/src/inside/components/EhrEvaluationInput.vue
+++ b/client/src/inside/components/EhrEvaluationInput.vue
@@ -1,28 +1,50 @@
 <template lang="pug">
-  div(class="ehr-eval-input")
-    div(class="evaluation-notes")
-      textarea(v-model="theNotes")
-    div(class="evaluation-controls")
-      ui-button(v-on:buttonClicked="cancelEvaluationNotes", :disabled="!enableActions", v-bind:secondary="true") Cancel
-      ui-button(v-on:buttonClicked="saveEvaluationNotes('saveNext')", :disabled="disableNext", class="is-pulled-right")  Save and next student
-      ui-button(v-on:buttonClicked="saveEvaluationNotes('saved')", :disabled="!enableActions", class="is-pulled-right")  Save
+  div
+    div(class="ehr-eval-input")
+      div(class="evaluation-notes")
+        textarea(v-model="theNotes")
+      div(class="evaluation-controls")
+        ui-button(v-on:buttonClicked="cancelEvaluationNotes", :disabled="!enableActions", v-bind:secondary="true") Cancel
+        ui-button(v-on:buttonClicked="saveEvaluationNotes('saveNext')", :disabled="disableNext", class="is-pulled-right")  Save and next student
+        ui-button(v-on:buttonClicked="saveEvaluationNotes('saved')", :disabled="!enableActions", class="is-pulled-right")  Save
+    ui-confirm(ref="confirmDialog", @confirm="handleConfirm", @abort="handleReset", @cancel="handleReset" set-footer)
 </template>
 
 <script>
 import UiButton from '../../app/ui/UiButton'
+import UiConfirm from '../../app/ui/UiConfirm'
 import StoreHelper from '../../helpers/store-helper'
+
+const HEADER = 'Your evaluation notes have not been saved'
+const TEXT = 'Would you like to...?'
+const CONFIRM =  {
+  beforeRouteLeave: 'Save and Continue',
+  previous: 'Save and previous',
+  next: 'Save and Next',
+}
+const CANCEL = 'Discard notes and continue'
+const LEAVE_PROMPT = 'Your evaluation notes have not been saved'
 
 export default {
   name: 'EhrEvaluationInput',
-  components: { UiButton },
+  components: {
+    UiButton,
+    UiConfirm 
+  },
   data: function () {
     return {
       theNotes: '',
-      asStored: ''
+      asStored: '',
+      proceed: false,
+      confirmStep: '',
+      next: null
     }
   },
+  
   props: {
-    enableNext: { type: Boolean }
+    enableNext: { type: Boolean },
+    shouldConfirmNavigation: {type: Boolean},
+    navigation: { type: String }
   },
   computed: {
     enableActions () {
@@ -33,16 +55,52 @@ export default {
     },
     asStoredEvaluationNotes () {
       return StoreHelper.getEvaluationNotes()
+    },
+    hasNewData () {
+      return (
+        this.theNotes && 
+        this.theNotes.length > 0 && 
+        this.theNotes !== this.asStoredEvaluationNotes
+      )
     }
   },
-  mounted: function (){
+  mounted: function (){ 
     this.loadDialog()
   },
+
+  created () {
+    this._setupEventHandlers()
+  },
+
+  beforeRouteLeave : function (to, from, next) {
+    console.log('beforeRouteLeave EhrEvaluationInput')
+    if(to.meta.layout !== 'inside' && this.hasNewData) {
+      this.confirmStep = 'beforeRouteLeave'
+      this.next = next
+      this.showConfirmationDialog()
+    } else {
+      next(true)
+    }
+  },
+
+  beforeDestroy () {
+    this._takeDownEventHandlers()
+  },
+
   watch: {
     asStoredEvaluationNotes: function (newData) {
       // console.log('EhrEvaluationInput watched')
       this.setNotes(newData)
-    }
+    },
+
+    shouldConfirmNavigation: function (shouldConfirm) {
+      if(shouldConfirm && this.hasNewData) {
+        this.confirmStep = 'navigation'
+        this.showConfirmationDialog()
+      } else {
+        this.$emit('proceedNavigation')
+      }
+    },  
   },
   methods: {
     setNotes (data) {
@@ -58,11 +116,71 @@ export default {
       this.$emit('canceled')
     },
     saveEvaluationNotes: function (event) {
-      return StoreHelper.saveEvaluationNotes(this.theNotes).then(() => {
-        this.$emit(event)
-      })
-    }
+      if (event) {
+        return StoreHelper.saveEvaluationNotes(this.theNotes).then(() => {
+          this.$emit(event)
+        })
+      } else {
+        return StoreHelper.saveEvaluationNotes(this.theNotes)
+      }
+      
+    },
+
+    beforeUnloadListener (event) {
+      console.log('beforeUnloadListen')
+      let e = event || window.event
+      if (this.hasNewData) {
+        e.preventDefault()
+        e.returnValue = LEAVE_PROMPT
+      }
+    },
+
+
+    _setupEventHandlers () {
+      const _this = this
+      this.windowUnloadHandler = function (eData) {
+        _this.beforeUnloadListener(eData)
+      }
+      window.addEventListener('beforeunload', this.windowUnloadHandler)
+    },  
+
+    _takeDownEventHandlers (pageKey) {
+      window.removeEventListener('beforeunload', this.windowUnloadHandler)
+    },
+
+    handleReset () {
+      console.log('handlingReset >> ', this.confirmStep)
+      if(this.confirmStep === 'navigation') {
+        this.$emit('proceedNavigation')
+      } else if (this.confirmStep === 'beforeRouteLeave') {
+        this.next(true)
+      }
+      this.proceed = false
+      this.confirmStep = ''
+      this.setNotes('')
+    },
+
+    showConfirmationDialog () {
+      const key =  this.confirmStep === 'navigation' ? this.navigation : this.confirmStep     
+      this.$refs.confirmDialog.showDialog(HEADER, TEXT, CONFIRM[key], CANCEL)
+    },
+
+    handleConfirm () {
+      this.saveEvaluationNotes()
+      switch(this.confirmStep) {
+      case 'beforeRouteLeave':
+        this.next(true)
+        break
+      case 'navigation':
+        this.$emit('proceedNavigation')
+        break
+      default:
+        this.saveEvaluationNotes('saved')
+      }
+      this.setNotes('')
+    },
   }
+  
 }
 </script>
 


### PR DESCRIPTION
I've taken your original PR, rebased onto master and squashed.  It's good but has one problem:
1. setup a system with at least two students, submit their work for an assignment and then log in as an instructor and evaluate the assignment.
2. edit the evaluation notes for each student saving each time.  In other words, add some notes to each student's work.
Now return to 1st student. Edit the note but do not save. Press the Next.  See the warning. Select Save and Next.
Notice how the second student's evaluation notes are not shown and the previous student's notes are shown.
The problem is the load activity function for the second student is not firing.

Please address this and create a new PR on the main repo.
Thanks